### PR TITLE
add environment variables for ecr-viewer database

### DIFF
--- a/terraform/implementation/ecs/_local.tf
+++ b/terraform/implementation/ecs/_local.tf
@@ -28,6 +28,14 @@ locals {
         {
           name  = "HOSTNAME",
           value = "0.0.0.0"
+        },
+        {
+          name = "DATABASE_TYPE",
+          value = var.ecr_viewer_database_type,
+        },
+        {
+          name = "DATABASE_SCHEMA",
+          value = var.ecr_viewer_database_schema,
         }
       ]
     },

--- a/terraform/implementation/ecs/_variable.tf
+++ b/terraform/implementation/ecs/_variable.tf
@@ -150,12 +150,13 @@ variable "vpc_cidr" {
 }
 
 variable "ecr_viewer_database_type" {
+  description = "The SQL variant used for the eCR data tables"
   type        = string
-  description = "Type of the ECR repositories"
   default     = "postgres"
 }
 
 variable "ecr_viewer_database_schema" {
+  description = "The database schema used for the eCR data tables"
   type        = string
   default     = "core"
 }

--- a/terraform/implementation/ecs/_variable.tf
+++ b/terraform/implementation/ecs/_variable.tf
@@ -148,3 +148,14 @@ variable "vpc_cidr" {
   type        = string
   default     = "176.24.0.0/16"
 }
+
+variable "ecr_viewer_database_type" {
+  type        = string
+  description = "Type of the ECR repositories"
+  default     = "postgres"
+}
+
+variable "ecr_viewer_database_schema" {
+  type        = string
+  default     = "core"
+}


### PR DESCRIPTION
## Summary
- Add two new environment variables for ecr viewer's DATABASE_TYPE and DATABASE_SCHEMA
- Part of [#2347](https://github.com/CDCgov/phdi/issues/2347)