### PR TITLE
Update DIBBS apps to 1.6.4

### DIFF
--- a/terraform/implementation/ecs/main.tf
+++ b/terraform/implementation/ecs/main.tf
@@ -23,4 +23,7 @@ module "ecs" {
   owner   = var.owner
   project = var.project
   tags    = local.tags
+
+  # If intent is to use the non-integrated viewer, set this to true (default is false)
+  # non_integrated_viewer = "true"
 }

--- a/terraform/modules/ecs/_local.tf
+++ b/terraform/modules/ecs/_local.tf
@@ -45,8 +45,15 @@ locals {
         {
           name  = "APP_ENV",
           value = "test"
+        },
+        {
+          name  = "NODE_ENV",
+          value = var.node_env
+        },
+        {
+          name = "NEXT_PUBLIC_BASEPATH",
+          value = var.ecr_viewer_basepath
         }
-
       ]
     },
     fhir-converter = {
@@ -148,7 +155,7 @@ locals {
         },
         {
           name  = "ECR_VIEWER_URL",
-          value = "http://ecr-viewer:3000"
+          value = "http://ecr-viewer:3000${var.ecr_viewer_basepath}"
         },
         {
           name  = "MESSAGE_PARSER_URL",

--- a/terraform/modules/ecs/_variable.tf
+++ b/terraform/modules/ecs/_variable.tf
@@ -99,7 +99,7 @@ variable "s3_viewer_bucket_role_name" {
 variable "phdi_version" {
   type        = string
   description = "Version of the PHDI application"
-  default     = "v1.6.3"
+  default     = "v1.6.4"
 }
 
 variable "service_data" {
@@ -160,7 +160,7 @@ variable "non_integrated_viewer" {
 
 variable "node_env" {
   type        = string
-  description = "The node environment"
+  description = "The app node environment"
   default     = "production"
 }
 

--- a/terraform/modules/ecs/_variable.tf
+++ b/terraform/modules/ecs/_variable.tf
@@ -99,7 +99,7 @@ variable "s3_viewer_bucket_role_name" {
 variable "phdi_version" {
   type        = string
   description = "Version of the PHDI application"
-  default     = "v1.6.1"
+  default     = "v1.6.3"
 }
 
 variable "service_data" {
@@ -156,4 +156,16 @@ variable "non_integrated_viewer" {
   type        = string
   description = "A flag to determine if the viewer is the non-integrated version"
   default     = "false"
+}
+
+variable "node_env" {
+  type        = string
+  description = "The node environment"
+  default     = "production"
+}
+
+variable "ecr_viewer_basepath" {
+  type        = string
+  description = "The basepath for the ecr-viewer"
+  default     = "/ecr-viewer"
 }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolve #18
 
## Changes Proposed

- Add `NODE_ENV` and `NEXT_PUBLIC_BASEPATH` env vars to the ecr-viewer
- Include defaults for the new terraform variables
- Update `ECR_VIEWER_URL` set on the orchestration service to use the basepath