### PR TITLE
move eCR metadata db variables to modules

### DIFF
--- a/terraform/implementation/ecs/_variable.tf
+++ b/terraform/implementation/ecs/_variable.tf
@@ -70,15 +70,3 @@ variable "vpc_cidr" {
   type        = string
   default     = "176.24.0.0/16"
 }
-
-variable "ecr_viewer_database_type" {
-  description = "The SQL variant used for the eCR data tables"
-  type        = string
-  default     = "postgres"
-}
-
-variable "ecr_viewer_database_schema" {
-  description = "The database schema used for the eCR data tables"
-  type        = string
-  default     = "core"
-}

--- a/terraform/implementation/ecs/main.tf
+++ b/terraform/implementation/ecs/main.tf
@@ -23,7 +23,7 @@ module "ecs" {
   owner   = var.owner
   project = var.project
   tags    = local.tags
-  
+
   # If intent is to pull from the phdi GHCR, set disable_ecr to true (default is false)
   # disable_ecr = true
   # If intent is to use the non-integrated viewer, set non_integrated_viewer to true (default is false)

--- a/terraform/modules/ecs/_local.tf
+++ b/terraform/modules/ecs/_local.tf
@@ -53,6 +53,14 @@ locals {
         {
           name  = "NEXT_PUBLIC_BASEPATH",
           value = var.ecr_viewer_basepath
+        },
+        {
+          name  = "METADATA_DATABASE_SCHEMA",
+          value = var.ecr_viewer_metadata_database_schema
+        },
+        {
+          name  = "METADATA_DATABASE_TYPE",
+          value = var.ecr_viewer_metadata_database_type
         }
       ]
     },

--- a/terraform/modules/ecs/_variable.tf
+++ b/terraform/modules/ecs/_variable.tf
@@ -190,3 +190,15 @@ Iynom6unaheZpS4DFIh2w9UCAwEAAQ==
 -----END PUBLIC KEY-----
           EOT
 }
+
+variable "ecr_viewer_metadata_database_schema" {
+  description = "The database schema used for the eCR metadata tables"
+  type        = string
+  default     = "core"
+}
+
+variable "ecr_viewer_metadata_database_type" {
+  description = "The SQL variant used for the eCR metadata tables"
+  type        = string
+  default     = "postgres"
+}


### PR DESCRIPTION
Set [environment variables](https://github.com/CDCgov/phdi/blob/dbd474b37b72614396b06c9e6971c8e0237b297b/containers/ecr-viewer/environment.d.ts#L16-L17) in eCR related to eCR Metadata db type and schema. These will become available in the next release of the eCR viewer.