### PR TITLE
GitHub action updates

### DIFF
--- a/.github/workflows/deployment_apply.yaml
+++ b/.github/workflows/deployment_apply.yaml
@@ -1,5 +1,5 @@
 name: Terraform Apply
-run-name: Terraform ${{ inputs.terraform_action }} ${{ inputs.workspace }} by @${{ github.actor }}
+run-name: Terraform apply ${{ inputs.workspace }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deployment_plan.yaml
+++ b/.github/workflows/deployment_plan.yaml
@@ -1,5 +1,5 @@
 name: Terraform Plan
-run-name: Terraform ${{ inputs.terraform_action }} ${{ inputs.workspace }} by @${{ github.actor }}
+run-name: Terraform plan ${{ inputs.workspace }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,7 +1,10 @@
-name: trivy
+name: Trivy Security Scan
 
 on:
   pull_request:
+  push:
+    branches: 
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Minor GitHub action updates:

- Update `Terraform Apply` and `Terraform Plan` `run-name` to remove the missing input and hardcode the specific action being run 
- Update the Trivy name to be more descriptive at a glance
- Update the Trivy job to run on pushes to the main branch