### PR TITLE
feat: add repository_dispatch trigger and tf_branch option

### DIFF
--- a/.github/workflows/deployment_apply.yaml
+++ b/.github/workflows/deployment_apply.yaml
@@ -2,6 +2,8 @@ name: Terraform Apply
 run-name: Terraform apply ${{ inputs.workspace }}${{ inputs.id }}:${{ inputs.dibbs-ecr-viewer-version }} by @${{ github.actor }}
 
 on:
+  repository_dispatch:
+    types: [trigger-dev-deploy]
   workflow_dispatch:
     inputs:
       workspace:
@@ -11,6 +13,11 @@ on:
         options:
           - dev
           - prod
+      tf_branch:
+        description: "The branch to use for the terraform code (optional, defaults to main)"
+        required: false
+        type: string
+        default: main
       id:
         description: "Unique id for environment (between 0 and 255)"
         required: true
@@ -62,13 +69,8 @@ jobs:
     steps:
       - name: Check Out Changes
         uses: actions/checkout@v4
-        if: ${{ github.event.client_payload.tf_branch != '' }}
         with:
-          ref: ${{ github.event.client_payload.tf_branch }}
-
-      - name: Check Out Changes (default branch)
-        uses: actions/checkout@v4
-        if: ${{ github.event.client_payload.tf_branch == '' }}
+          ref: ${{ inputs.tf_branch }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/trigger_dev_deploy.yaml
+++ b/.github/workflows/trigger_dev_deploy.yaml
@@ -1,0 +1,45 @@
+name: Trigger Dev Deploy or Plan
+run-name: Trigger Dev ${{ github.event.client_payload.event_type }} for ${{ github.event.client_payload.workspace }}${{ github.event.client_payload.dev_id }}:${{ github.event.client_payload.version }} by @${{ github.actor }}
+
+on:
+  repository_dispatch:
+    types: [trigger-dev-deploy, trigger-dev-plan]
+
+jobs:
+  trigger_dev_deploy:
+    name: Trigger Dev Deploy
+    if: ${{ github.event.client_payload.event_type == 'trigger-dev-deploy' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Changes
+        uses: actions/checkout@v4
+
+      - name: Trigger Dev Deploy
+        uses: ./deployment_apply.yaml
+        with:
+          workspace: dev
+          id: ${{ github.event.client_payload.dev_id }}
+          dibbs-ecr-viewer-version: ${{ github.event.client_payload.version }}
+          dibbs-ecr-viewer-config-name: ${{ github.event.client_payload.config_name }}
+          dibbs-ecr-viewer-auth-provider: ad
+          tf_branch: ${{ github.event.client_payload.tf_branch != '' && github.event.client_payload.tf_branch || 'main' }}
+          config_name: ${{ github.event.client_payload.config_name }}
+
+  trigger_dev_plan:
+    name: Trigger Dev Plan
+    if: ${{ github.event.client_payload.event_type == 'trigger-dev-plan' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Changes
+        uses: actions/checkout@v4
+
+      - name: Trigger Dev Plan
+        uses: ./deployment_plan.yaml
+        with:
+          workspace: dev
+          id: ${{ github.event.client_payload.dev_id }}
+          dibbs-ecr-viewer-version: ${{ github.event.client_payload.version }}
+          dibbs-ecr-viewer-config-name: ${{ github.event.client_payload.config_name }}
+          dibbs-ecr-viewer-auth-provider: ad
+          tf_branch: ${{ github.event.client_payload.tf_branch != '' && github.event.client_payload.tf_branch || 'main' }}
+          config_name: ${{ github.event.client_payload.config_name }}


### PR DESCRIPTION
## Changes Proposed

- Updated the Terraform deployment workflow to support repository dispatch events by adding a new event type trigger 'trigger-dev-deploy' and 'trigger-dev-plan'.
- Created a new workflow (trigger_dev_deploy.yaml) that supports both deployment and plan actions, triggering the appropriate job based on the repository dispatch event type.

## Testing

- Trigger the repository dispatch events for both 'trigger-dev-deploy' and 'trigger-dev-plan' to ensure each workflow initiates and processes correctly.
- Verify that the specified branch (or the default 'main') is used during the checkout step in the Terraform actions.
- Check the logs to confirm that deployment_apply.yaml and deployment_plan.yaml are triggered appropriately based on the event type.