### PR TITLE
Updating ECS module ref to commit with proxy

### DIFF
--- a/terraform/implementation/ecs/main.tf
+++ b/terraform/implementation/ecs/main.tf
@@ -100,8 +100,8 @@ module "ecs" {
     fhir-converter = {
       cpu           = 2048
       memory        = 4096
-      max_capacity  = 5
-      min_capacity  = 1
+      max_capacity  = 2
+      min_capacity  = 2
       target_cpu    = 60
       target_memory = 70
     }

--- a/terraform/implementation/ecs/main.tf
+++ b/terraform/implementation/ecs/main.tf
@@ -35,7 +35,7 @@ module "db" {
 }
 
 module "ecs" {
-  source = "git::https://github.com/CDCgov/terraform-aws-dibbs-ecr-viewer.git?ref=laura/ha-proxy"
+  source = "git::https://github.com/CDCgov/terraform-aws-dibbs-ecr-viewer.git?ref=ba64e72de946de9fda8406dcdee8294baf842ab6"
 
   public_subnet_ids  = flatten(module.vpc.public_subnets)
   private_subnet_ids = flatten(module.vpc.private_subnets)
@@ -104,8 +104,8 @@ module "ecs" {
     fhir-converter = {
       cpu           = 2048
       memory        = 4096
-      max_capacity  = 2
-      min_capacity  = 2
+      max_capacity  = 5
+      min_capacity  = 1
       target_cpu    = 60
       target_memory = 70
     }

--- a/terraform/implementation/ecs/main.tf
+++ b/terraform/implementation/ecs/main.tf
@@ -35,7 +35,7 @@ module "db" {
 }
 
 module "ecs" {
-  source = "git::https://github.com/CDCgov/terraform-aws-dibbs-ecr-viewer.git?ref=8e1ee72d639a7def04d1d1c4e33b21cb73e0866b"
+  source = "git::https://github.com/CDCgov/terraform-aws-dibbs-ecr-viewer.git?ref=laura/ha-proxy"
 
   public_subnet_ids  = flatten(module.vpc.public_subnets)
   private_subnet_ids = flatten(module.vpc.private_subnets)


### PR DESCRIPTION
## Summary

This PR updates the ECS module to point to the latest commit in the terraform-aws-dibbs-ecr-viewer repo with the new FHIR Converter HAProxy:

https://github.com/CDCgov/terraform-aws-dibbs-ecr-viewer/commit/ba64e72de946de9fda8406dcdee8294baf842ab6
