### PR TITLE
feat(security): add inspector2:Enable and update ECS module ref

### DIFF
--- a/terraform/implementation/ecs/README.md
+++ b/terraform/implementation/ecs/README.md
@@ -17,7 +17,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_db"></a> [db](#module\_db) | ../../modules/db | n/a |
-| <a name="module_ecs"></a> [ecs](#module\_ecs) | git::https://github.com/CDCgov/terraform-aws-dibbs-ecr-viewer.git | e7b7e4f5157348f65700a896f215c83370a9b9a0 |
+| <a name="module_ecs"></a> [ecs](#module\_ecs) | git::https://github.com/CDCgov/terraform-aws-dibbs-ecr-viewer.git | 075501afb49604c2b4f7b61e1bdb47cf8a3e435d |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git | 9ffd9c66f3d7eb4b5bc2d7bc7d049f794b127693 |
 
 ## Resources

--- a/terraform/implementation/ecs/main.tf
+++ b/terraform/implementation/ecs/main.tf
@@ -35,7 +35,7 @@ module "db" {
 }
 
 module "ecs" {
-  source = "git::https://github.com/CDCgov/terraform-aws-dibbs-ecr-viewer.git?ref=e7b7e4f5157348f65700a896f215c83370a9b9a0"
+  source = "git::https://github.com/CDCgov/terraform-aws-dibbs-ecr-viewer.git?ref=075501afb49604c2b4f7b61e1bdb47cf8a3e435d"
 
   public_subnet_ids  = flatten(module.vpc.public_subnets)
   private_subnet_ids = flatten(module.vpc.private_subnets)

--- a/terraform/modules/oidc/_data.tf
+++ b/terraform/modules/oidc/_data.tf
@@ -102,6 +102,7 @@ data "aws_iam_policy_document" "wildcard" {
       "iam:GetRolePolicy",
       "inspector2:ListAccountPermissions",
       "inspector2:Disable",
+      "inspector2:Enable",
       "kms:CreateKey",
       "kms:CreateAlias",
       "kms:DescribeKey",


### PR DESCRIPTION
## Summary
Add `inspector2:Enable` to the wildcard IAM policy and update the ECS module ref to the latest commit.

## Changes
- **terraform/modules/oidc/_data.tf:** Added `inspector2:Enable` action to the wildcard IAM policy document
- **terraform/implementation/ecs/main.tf:** Updated ECS module ref from `e7b7e4f...` to `075501a...`
- **terraform/implementation/ecs/README.md:** Auto-generated docs update reflecting new module ref

## Why
- `inspector2:Enable` is required for the OIDC role to enable Inspector2 scanning

## Testing
- [ ] `terraform/utilities/utils.sh` passes
- [ ] `terraform plan` runs without errors

## Related
- Follow-up to WAF trigger from file metadata work