### PR TITLE
fix: Using version and latest instead of preferred_versions

### DIFF
--- a/terraform/modules/db/_local.tf
+++ b/terraform/modules/db/_local.tf
@@ -1,9 +1,9 @@
 locals {
-  vpc_name                  = "${var.project}-${var.owner}-${terraform.workspace}"
-  sqlserver_engine          = "sqlserver-ex"
-  sqlserver_engine_version  = "16.00.4165.4.v1"
-  sqlserver_instance_class  = "db.t3.micro"
-  postgresql_engine         = "postgres"
-  postgresql_engine_version = "16.8"
-  postgresql_instance_class = "db.t3.micro"
+  vpc_name                        = "${var.project}-${var.owner}-${terraform.workspace}"
+  sqlserver_engine                = "sqlserver-ex"
+  sqlserver_engine_version        = "16.00.4165.4.v1"
+  sqlserver_instance_class        = "db.t3.micro"
+  postgresql_engine               = "postgres"
+  postgresql_engine_major_version = "16"
+  postgresql_instance_class       = "db.t3.micro"
 }

--- a/terraform/modules/db/postgresql.tf
+++ b/terraform/modules/db/postgresql.tf
@@ -1,6 +1,7 @@
 data "aws_rds_engine_version" "postgresql" {
   engine             = local.postgresql_engine
-  preferred_versions = [local.postgresql_engine_version]
+  version            = [local.postgresql_engine_major_version]
+  latest             = true
 }
 
 resource "aws_db_instance" "postgresql" {


### PR DESCRIPTION
Fixes an issue where the RDS PostgreSQL deployment fails with a `no RDS engine versions match the criteria` error due to AWS possibly deprecating specific minor patch strings.

Switched from `preferred_versions` which expects hard-coded versions to `version` which acts as a major version filter plus `latest` so that TF fetches the highest available minor patch level of PostgreSQL 16.
